### PR TITLE
Update dashboard_zone_one.tpl

### DIFF
--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -26,10 +26,10 @@
 	<div class="panel-heading">
 		<i class="icon-time"></i> {l s='Activity overview' mod='dashactivity'}
 		<span class="panel-heading-action">
-			<a class="list-toolbar-btn" href="#" onclick="toggleDashConfig('dashactivity'); return false;" title="configure">
+			<a class="list-toolbar-btn" href="#" onclick="toggleDashConfig('dashactivity'); return false;" title="{l s='Configure' mod='dashactivity'}">
 				<i class="process-icon-configure"></i>
 			</a>
-			<a class="list-toolbar-btn" href="#" onclick="refreshDashboard('dashactivity'); return false;" title="refresh">
+			<a class="list-toolbar-btn" href="#" onclick="refreshDashboard('dashactivity'); return false;" title="{l s='Refresh' mod='dashactivity'}">
 				<i class="process-icon-refresh"></i>
 			</a>
 		</span>


### PR DESCRIPTION
- the string not appear in the translation tool - replaced double-quotes to single-quotes fix the problem
- icon removed from the link - underline icon not looking good
