### PR TITLE
[*] MO : Only display out of stock products, when Stock Management is enabled.

### DIFF
--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -85,12 +85,14 @@
 					<span id="abandoned_cart"></span>
 				</span>
 			</li>
+			{if $PS_STOCK_MANAGEMENT}
 			<li>
 				<span class="data_label"><a href="{$link->getAdminLink('AdminTracking')|escape:'html':'UTF-8'}">{l s='Out of Stock Products' mod='dashactivity'}</a></span>
 				<span class="data_value size_l">
 					<span id="products_out_of_stock"></span>
 				</span>
 			</li>
+			{/if}
 		</ul>
 	</section>
 	<section id="dash_notifications" class="loading">


### PR DESCRIPTION
Only display out of stock products, when Stock Management is enabled.
