### PR TITLE
Fix dashboard error when click on Total subscribers

### DIFF
--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -130,7 +130,7 @@
 				</span>
 			</li>
 			<li>
-				<span class="data_label"><a href="{$link->getAdminLink('AdminModules')|escape:'html':'UTF-8'}&amp;configure=blocknewsletter&amp;module_name=blocknewsletter">{l s='Total Subscribers' d='Modules.Dashactivity.Admin'}</a></span>
+				<span class="data_label"><a href="{$link->getAdminLink('AdminModules')|escape:'html':'UTF-8'}&amp;configure=ps_emailsubscription&amp;module_name=ps_emailsubscription">{l s='Total Subscribers' d='Modules.Dashactivity.Admin'}</a></span>
 				<span class="data_value size_md">
 					<span id="total_suscribers"></span>
 				</span>


### PR DESCRIPTION
http://forge.prestashop.com/browse/BOOM-4104
Adjusted Dashboard Total subscribers link to point to ps_emailsubscription configuration page instead of blocknewsletter that doesn't exists anymore.