### PR TITLE
Remove addjquery

### DIFF
--- a/dashactivity.php
+++ b/dashactivity.php
@@ -69,10 +69,6 @@ class dashactivity extends Module
     public function hookActionAdminControllerSetMedia()
     {
         if (get_class($this->context->controller) == 'AdminDashboardController') {
-            if (method_exists($this->context->controller, 'addJquery')) {
-                $this->context->controller->addJquery();
-            }
-
             $this->context->controller->addJs($this->_path.'views/js/'.$this->name.'.js');
             $this->context->controller->addJs(
                 array(


### PR DESCRIPTION
Remove usage of addJquery method since from prestashop 1.7.7 jquery is always included in back office. This also fixes javascript errors on 1.7.7 dashboard page.