### PR TITLE
Remove code related to live update (`push`)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>dashactivity</name>
 	<displayName><![CDATA[Dashboard Activity]]></displayName>
-	<version><![CDATA[2.1.0]]></version>
+	<version><![CDATA[2.1.1]]></version>
 	<description><![CDATA[]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[dashboard]]></tab>

--- a/dashactivity.php
+++ b/dashactivity.php
@@ -36,11 +36,8 @@ class dashactivity extends Module
     {
         $this->name = 'dashactivity';
         $this->tab = 'dashboard';
-        $this->version = '2.1.0';
+        $this->version = '2.1.1';
         $this->author = 'PrestaShop';
-        $this->push_filename = _PS_CACHE_DIR_.'push/activity';
-        $this->allow_push = true;
-        $this->push_time_limit = 180;
 
         parent::__construct();
         $this->displayName = $this->trans('Dashboard Activity', array(), 'Modules.Dashactivity.Admin');
@@ -58,11 +55,6 @@ class dashactivity extends Module
         return (parent::install()
             && $this->registerHook('dashboardZoneOne')
             && $this->registerHook('dashboardData')
-            && $this->registerHook('actionObjectOrderAddAfter')
-            && $this->registerHook('actionObjectCustomerAddAfter')
-            && $this->registerHook('actionObjectCustomerMessageAddAfter')
-            && $this->registerHook('actionObjectCustomerThreadAddAfter')
-            && $this->registerHook('actionObjectOrderReturnAddAfter')
             && $this->registerHook('actionAdminControllerSetMedia')
         );
     }
@@ -493,30 +485,5 @@ class dashactivity extends Module
             'DASHACTIVITY_CART_ABANDONED_MAX' => Tools::getValue('DASHACTIVITY_CART_ABANDONED_MAX', Configuration::get('DASHACTIVITY_CART_ABANDONED_MAX')),
             'DASHACTIVITY_VISITOR_ONLINE' => Tools::getValue('DASHACTIVITY_VISITOR_ONLINE', Configuration::get('DASHACTIVITY_VISITOR_ONLINE')),
         );
-    }
-
-    public function hookActionObjectCustomerMessageAddAfter($params)
-    {
-        return $this->hookActionObjectOrderAddAfter($params);
-    }
-
-    public function hookActionObjectCustomerThreadAddAfter($params)
-    {
-        return $this->hookActionObjectOrderAddAfter($params);
-    }
-
-    public function hookActionObjectCustomerAddAfter($params)
-    {
-        return $this->hookActionObjectOrderAddAfter($params);
-    }
-
-    public function hookActionObjectOrderReturnAddAfter($params)
-    {
-        return $this->hookActionObjectOrderAddAfter($params);
-    }
-
-    public function hookActionObjectOrderAddAfter($params)
-    {
-        Tools::changeFileMTime($this->push_filename);
     }
 }

--- a/upgrade/upgrade-2.1.1.php
+++ b/upgrade/upgrade-2.1.1.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_1_1($object)
+{
+    return $object->unregisterHook('actionObjectOrderAddAfter')
+        && $object->unregisterHook('actionObjectCustomerAddAfter')
+        && $object->unregisterHook('actionObjectCustomerMessageAddAfter')
+        && $object->unregisterHook('actionObjectCustomerThreadAddAfter')
+        && $object->unregisterHook('actionObjectOrderReturnAddAfter');
+}

--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
-<section id="dashactivity" class="panel widget{if $allow_push} allow_push{/if}">
+<section id="dashactivity" class="panel widget">
 	<div class="panel-heading">
 		<i class="icon-time"></i> {l s='Activity overview' d='Modules.Dashactivity.Admin'}
 		<span class="panel-heading-action">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR aims to remove an unused feature (live update) that has been removed from the core but make this module throw an exception because even though the feature is not used, it requires a smarty variable not available anymore.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes PrestaShop/Prestashop#27028
| How to test?  | On PrestaShop develop:<br>1. Disable modules `Dashproducts` & `Dashtrends`<br>2. Comment the line https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L2185 (`'allow_push' => false, // required by dashboard modules`)<br>3. Install this module<br>4. No error should appear in the page Dashboard

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
