### PR TITLE
Adds custom hooks as in form of shortcodes for online and unique visitors to use in front end templates

### DIFF
--- a/dashactivity.php
+++ b/dashactivity.php
@@ -37,6 +37,7 @@ class dashactivity extends Module
         $this->tab = 'administration';
         $this->version = '2.1.0';
         $this->author = 'PrestaShop';
+        $this->bootstrap = true;
 
         parent::__construct();
         $this->displayName = $this->trans('Dashboard Activity', [], 'Modules.Dashactivity.Admin');
@@ -512,5 +513,63 @@ class dashactivity extends Module
         ]);
 
         return $this->context->smarty->fetch($this->local_path . 'views/templates/hook/uniqueVisitors.tpl');
+    }
+
+    public function renderFormOnlineAndUniqueVisitorsShortcodeHooks()
+    {
+        $fields_form = array(
+            'form' => array(
+                'legend' => array(
+                    'title' => $this->trans('Online And Unique Visitors Shortcode Hooks', array(), 'Modules.Dashactivity.Config'),
+                    'icon' => 'icon-cogs'
+                ),
+                'input' => array(
+                    array(
+                        'type' => 'text',
+                        'disabled' => true,
+                        'label' => $this->trans('Online visitors', array(), 'Modules.Dashactivity.Config'),
+                        'hint' => $this->trans('Online visitors currently: %d', array(dashactivity::getOnlineVisitors()), 'Modules.Dashactivity.Config'),
+                        'desc' => $this->trans('Copy and paste in your tpl files.', array(), 'Modules.Dashactivity.Config'),
+                        'name' => 'DASHACTIVITY_HOOK_SHORTCODE_VISITORS_ONLINE'
+                    ),
+                    array(
+                        'type' => 'text',
+                        'disabled' => true,
+                        'label' => $this->trans('Unique visitors', array(), 'Modules.Dashactivity.Config'),
+                        'hint' => $this->trans('Unique visitors between (%s) and (%s) are %d', array(date('Y-m-d') . ' 00:00:00', date('Y-m-d') . ' 23:59:59', dashactivity::getUniqueVisitors()), 'Modules.Dashactivity.Config'),
+                        'desc' => $this->trans('Copy and paste in your tpl files.', array(), 'Modules.Dashactivity.Config'),
+                        'name' => 'DASHACTIVITY_HOOK_SHORTCODE_VISITORS_UNIQUE'
+                    ),
+                ),
+            ),
+        );
+
+        $lang = new Language((int)Configuration::get('PS_LANG_DEFAULT'));
+
+        $helper = new HelperForm();
+        $helper->default_form_language = $lang->id;
+        $helper->module = $this;
+        $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
+        $helper->tpl_vars = array(
+            'uri' => $this->getPathUri(),
+            'fields_value' => $this->getFormOnlineAndUniqueVisitorsShortcodeHooksFieldsValues(),
+            'languages' => $this->context->controller->getLanguages(),
+            'id_language' => $this->context->language->id
+        );
+
+        return $helper->generateForm(array($fields_form));
+    }
+
+    public function getFormOnlineAndUniqueVisitorsShortcodeHooksFieldsValues()
+    {
+        $fields['DASHACTIVITY_HOOK_SHORTCODE_VISITORS_ONLINE'] = "{hook h='dashactivityOnlineVisitors' mod='dashactivity'}";
+        $fields['DASHACTIVITY_HOOK_SHORTCODE_VISITORS_UNIQUE'] = "{hook h='dashactivityUniqueVisitors' mod='dashactivity'}";
+        
+        return $fields;
+    }
+
+    public function getContent()
+    {
+        return $this->renderFormOnlineAndUniqueVisitorsShortcodeHooks();
     }
 }

--- a/dashactivity.php
+++ b/dashactivity.php
@@ -55,6 +55,8 @@ class dashactivity extends Module
             && $this->registerHook('dashboardZoneOne')
             && $this->registerHook('dashboardData')
             && $this->registerHook('actionAdminControllerSetMedia')
+            && $this->registerHook('dashactivityOnlineVisitors')
+            && $this->registerHook('dashactivityUniqueVisitors')
         ;
     }
 
@@ -490,5 +492,25 @@ class dashactivity extends Module
         $unique_visitors = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->getValue($sql);
 
         return $unique_visitors;
+    }
+
+    public function hookDashactivityOnlineVisitors()
+    {
+        $onlineVisitors = dashactivity::getOnlineVisitors();
+        $this->context->smarty->assign([
+            'onlineVisitors' => $onlineVisitors
+        ]);
+
+        return $this->context->smarty->fetch($this->local_path . 'views/templates/hook/onlineVisitors.tpl');
+    }
+
+    public function hookDashactivityUniqueVisitors()
+    {
+        $uniqueVisitors = dashactivity::getUniqueVisitors();
+        $this->context->smarty->assign([
+            'uniqueVisitors' => $uniqueVisitors
+        ]);
+
+        return $this->context->smarty->fetch($this->local_path . 'views/templates/hook/uniqueVisitors.tpl');
     }
 }

--- a/views/templates/hook/onlineVisitors.tpl
+++ b/views/templates/hook/onlineVisitors.tpl
@@ -1,0 +1,1 @@
+{$onlineVisitors}

--- a/views/templates/hook/uniqueVisitors.tpl
+++ b/views/templates/hook/uniqueVisitors.tpl
@@ -1,0 +1,1 @@
+{$uniqueVisitors}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This update adds an improvement to the module with core code of the module, and lets the developers show online visitors and unique visitors in FO with just a shortcode hook for tpl files. This also has tpl files for both online and unique visitors so that developers can override them easily in their themes.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no (idk)
| How to test? | 1. Install this version of `dashactivity` module. 2. Open config form of module in BO and copy shortcode examples 3. Paste somewhere in your template and check it works

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
