### PR TITLE
Avoid error due to ipv6 in maintenance ip

### DIFF
--- a/dashactivity.php
+++ b/dashactivity.php
@@ -149,7 +149,7 @@ class dashactivity extends Module
         extract($row);
 
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))),'strlen')); // @phpstan-ignore-line
+            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))), '\strlen'));
         }
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {
             $sql = 'SELECT c.id_guest, c.ip_address, c.date_add, c.http_referer, pt.name as page

--- a/dashactivity.php
+++ b/dashactivity.php
@@ -149,7 +149,7 @@ class dashactivity extends Module
         extract($row);
 
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))),'strlen'));
+            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))),'strlen')); // @phpstan-ignore-line
         }
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {
             $sql = 'SELECT c.id_guest, c.ip_address, c.date_add, c.http_referer, pt.name as page

--- a/dashactivity.php
+++ b/dashactivity.php
@@ -149,7 +149,7 @@ class dashactivity extends Module
         extract($row);
 
         if ($maintenance_ips = Configuration::get('PS_MAINTENANCE_IP')) {
-            $maintenance_ips = implode(',', array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))));
+            $maintenance_ips = implode(',', array_filter(array_map('ip2long', array_map('trim', explode(',', $maintenance_ips))),'strlen'));
         }
         if (Configuration::get('PS_STATSDATA_CUSTOMER_PAGESVIEWS')) {
             $sql = 'SELECT c.id_guest, c.ip_address, c.date_add, c.http_referer, pt.name as page


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Prestashop manages ip adresses for several needs. For exemple the class connection.php records the ip address in the database. This record is done with ip2long converting. ip2long manages only ipv4 adresses, so there is a 0 in the record. dashactivity module checks if connection ip is the same than the ones in the maintenance ip. If there is at least one ipv6 address in several maintenance ip adresses, the module doesn't show data on dashboard due to a sql error because there is ",," in the query.
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31831.
| How to test?  | Put 1 ipv4 then 1ipv6 then 1 ipv4 in maintenance ip, save. Go to dashboard. you see data of visitors, carts, ... instead of only arrow turning

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
