### PR TITLE
remove unique visitor link as module statsvisits is deprecated

### DIFF
--- a/views/templates/hook/dashboard_zone_one.tpl
+++ b/views/templates/hook/dashboard_zone_one.tpl
@@ -149,12 +149,6 @@
 				</span>
 			</li>
 			<li>
-				<span class="data_label"><a href="{$link->getAdminLink('AdminStats')|escape:'html':'UTF-8'}&amp;module=statsvisits">{l s='Unique Visitors' d='Modules.Dashactivity.Admin'}</a></span>
-				<span class="data_value size_md">
-					<span id="unique_visitors"></span>
-				</span>
-			</li>
-			<li>
 				<span class="data_label">{l s='Traffic Sources' d='Modules.Dashactivity.Admin'}</span>
 				<ul class="data_list_small" id="dash_traffic_source">
 				</ul>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | module statsvisits has been archived, so the link is removed
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/34322
| How to test?  | Check link is not here anymore

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
