### PR TITLE
Fix: BO - dashactivity - module can't be SAVED properly

### DIFF
--- a/dashactivity.php
+++ b/dashactivity.php
@@ -430,4 +430,24 @@ class dashactivity extends Module
             'DASHACTIVITY_VISITOR_ONLINE' => Tools::getValue('DASHACTIVITY_VISITOR_ONLINE', Configuration::get('DASHACTIVITY_VISITOR_ONLINE')),
         ];
     }
+
+    /**
+     * Save dashboard configuration
+     *
+     * @param array $config
+     *
+     * @return bool determines if there are errors or not
+     */
+    public function saveDashConfig(array $config)
+    {
+        if (!$this->getPermission('configure')) {
+            return true;
+        }
+
+        foreach (array_keys($this->getConfigFieldsValues()) as $fieldName) {
+            Configuration::updateValue($fieldName, (int) $config[$fieldName]);
+        }
+
+        return false;
+    }
 }

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -5,3 +5,4 @@ parameters:
   ignoreErrors:
     - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'
     - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, string given.#'
+    - '#Parameter \#1 \$variable of method ModuleCore::getPermission\(\) expects array, string given.#'

--- a/tests/phpstan/phpstan-1.7.8.neon
+++ b/tests/phpstan/phpstan-1.7.8.neon
@@ -5,3 +5,4 @@ parameters:
   ignoreErrors:
     - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, false given.#'
     - '#Parameter \#1 \$share of static method ShopCore::addSqlRestriction\(\) expects int, string given.#'
+    - '#Parameter \#1 \$variable of method ModuleCore::getPermission\(\) expects array, string given.#'


### PR DESCRIPTION
Added method "saveDashConfig"

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The configuration should be saved
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#37033
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
