### PR TITLE
Qualify the shop restriction in the product reviews count

### DIFF
--- a/dashactivity.php
+++ b/dashactivity.php
@@ -258,7 +258,7 @@ class dashactivity extends Module
 				' . Shop::addSqlAssociation('product', 'p') . '
 				WHERE pc.deleted = 0
 				AND pc.`date_add` BETWEEN "' . pSQL($params['date_from']) . '" AND "' . pSQL($params['date_to']) . '"
-				' . Shop::addSqlRestriction(Shop::SHARE_ORDER)
+				' . Shop::addSqlRestriction(Shop::SHARE_ORDER, 'product_shop')
             );
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The product reviews count joins three tables and then restricts on an unqualified `id_shop`. On a shop whose `product` table still carries a legacy `id_shop` column, that column exists on two tables in the query and MySQL answers `#1052 - Column 'id_shop' in where clause is ambiguous`, so the dashboard activity block fails. Qualifying the restriction with the `product_shop` alias, which is the table the value is meant to be read from, removes the ambiguity.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#35792.
| How to test?  | See below.

### How to test

The generated query is:

```sql
SELECT COUNT(*) FROM ps_product_comment pc
LEFT JOIN ps_product p ON (pc.id_product = p.id_product)
INNER JOIN ps_product_shop product_shop ON (product_shop.id_product = p.id_product AND product_shop.id_shop = 1)
WHERE pc.deleted = 0 AND id_shop IN (1)
```

Reproduced by standing in for the legacy schema with a copy of `product` carrying an `id_shop` column, on MySQL 8.4:

```
unqualified   ERROR 1052 (23000): Column 'id_shop' in where clause is ambiguous
qualified     runs, returns a count
```

A shop whose `product` table has no `id_shop` never sees the error, because the bare name then resolves to `product_shop.id_shop` on its own. That is also why the change is a no-op there: it names the column the query was already resolving to.

### Scope

Only this query is changed. The other unqualified `Shop::addSqlRestriction()` calls in the file read from a single table - `connections`, `cart`, `customer` - so no ambiguity is possible, and the one at line 249 joins `orders` with `order_state`, which has no `id_shop` column.
